### PR TITLE
Add configConnection lambda

### DIFF
--- a/SQLiter/src/commonMain/kotlin/co/touchlab/sqliter/DatabaseConfiguration.kt
+++ b/SQLiter/src/commonMain/kotlin/co/touchlab/sqliter/DatabaseConfiguration.kt
@@ -29,7 +29,8 @@ data class DatabaseConfiguration(
     val inMemory: Boolean = false,
     val basePath: String? = null,
     val key: String? = null,
-    val rekey: String? = null
+    val rekey: String? = null,
+    val configConnection: (DatabaseConnection, Long) -> Unit = { _, _ -> }
 ) {
     init {
         checkFilename(name)

--- a/SQLiter/src/nativeCommonMain/kotlin/co/touchlab/sqliter/NativeDatabaseManager.kt
+++ b/SQLiter/src/nativeCommonMain/kotlin/co/touchlab/sqliter/NativeDatabaseManager.kt
@@ -45,16 +45,18 @@ class NativeDatabaseManager(private val path:String,
         lock.lock()
 
         try {
-            val conn = NativeDatabaseConnection(this, nativeOpen(
-                path,
-                CREATE_IF_NECESSARY,
-                "sqliter",
-                false,
-                false,
-                -1,
-                -1,
-                configuration.busyTimeout
-            ))
+            val connectionPtrArg = nativeOpen(
+                    path,
+                    CREATE_IF_NECESSARY,
+                    "sqliter",
+                    false,
+                    false,
+                    -1,
+                    -1,
+                    configuration.busyTimeout
+            )
+            val conn = NativeDatabaseConnection(this, connectionPtrArg)
+            configuration.configConnection(conn, connectionPtrArg)
 
             if (configuration.rekey == null) {
                 configuration.key?.let { conn.setCipherKey(it) }

--- a/SQLiter/src/nativeCommonTest/kotlin/co/touchlab/sqliter/DatabaseConfigurationTest.kt
+++ b/SQLiter/src/nativeCommonTest/kotlin/co/touchlab/sqliter/DatabaseConfigurationTest.kt
@@ -71,6 +71,27 @@ class DatabaseConfigurationTest : BaseDatabaseTest(){
     }
 
     @Test
+    fun configConnection(){
+        var called = false
+        val config = DatabaseConfiguration(name = "configConnection", version = 1, create = { _ -> }, configConnection = { c, ptr ->
+            assertNotEquals(0L, ptr)
+            assertNotNull(c)
+            called = true
+        })
+
+        var conn: DatabaseConnection? = null
+        try {
+            val manager = createDatabaseManager(config)
+            conn = manager.createMultiThreadedConnection()
+
+            assertTrue(called)
+        } finally {
+            conn?.close()
+            DatabaseFileContext.deleteDatabase(config)
+        }
+    }
+
+    @Test
     fun journalModeSetting()
     {
         val manager = createDatabaseManager(DatabaseConfiguration(name = TEST_DB_NAME, version = 1,


### PR DESCRIPTION
Allows low-level configuration of the connection with C APIs (useful for FTS5 or other module-type configuration) as well as access to the connection, in case using higher-level functions is desired.