### PR TITLE
Set key pragma in a query instead of statement

### DIFF
--- a/SQLiter/src/commonMain/kotlin/co/touchlab/sqliter/DatabaseConnection.kt
+++ b/SQLiter/src/commonMain/kotlin/co/touchlab/sqliter/DatabaseConnection.kt
@@ -60,7 +60,7 @@ fun DatabaseConnection.stringForQuery(sql:String):String = withStatement(sql){
  * @param cipherKey the database cipher key
  */
 fun DatabaseConnection.setCipherKey(cipherKey: String) {
-    withStatement("PRAGMA key = \"$cipherKey\";") { execute() }
+    stringForQuery("PRAGMA key = \"$cipherKey\";")
 }
 
 /**
@@ -71,7 +71,7 @@ fun DatabaseConnection.setCipherKey(cipherKey: String) {
  */
 fun DatabaseConnection.resetCipherKey(oldKey: String, newKey: String) {
     setCipherKey(oldKey)
-    withStatement("PRAGMA rekey = \"$newKey\";") { execute() }
+    stringForQuery("PRAGMA rekey = \"$newKey\";")
 }
 
 /**


### PR DESCRIPTION
This is because SQLCipher returns a row with "ok" after the key is set. This trips a check in the statement logic that throws an error if a row is returned