### PR TITLE
Support setting recursive_triggers and synchronous.

### DIFF
--- a/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/DatabaseConfiguration.kt
+++ b/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/DatabaseConfiguration.kt
@@ -36,7 +36,9 @@ data class DatabaseConfiguration(
         val busyTimeout: Int = 5000,
         val pageSize: Int? = null,
         val basePath: String? = null,
-        )
+        val synchronousFlag: SynchronousFlag? = null,
+        val recursiveTriggers: Boolean = false
+    )
     data class Logging(
         val logger: Logger = WarningLogger,
         val verboseDataCalls: Boolean = false
@@ -93,4 +95,8 @@ enum class JournalMode {
                 DELETE
             }
     }
+}
+
+enum class SynchronousFlag(val value: Int) {
+    OFF(0), NORMAL(1), FULL(2), EXTRA(3);
 }

--- a/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/DatabaseConnection.kt
+++ b/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/DatabaseConnection.kt
@@ -107,10 +107,15 @@ fun DatabaseConnection.updateJournalMode(value: JournalMode): JournalMode {
 }
 
 fun DatabaseConnection.updateForeignKeyConstraints(enabled: Boolean) {
-    val newValue = if (enabled) {
-        1
-    } else {
-        0
-    }
-    withStatement("PRAGMA foreign_keys=$newValue") { execute() }
+    withStatement("PRAGMA foreign_keys=${enabled.toInt()}") { execute() }
 }
+
+fun DatabaseConnection.updateSynchronousFlag(flag: SynchronousFlag) {
+    withStatement("PRAGMA synchronous=${flag.value}") { execute() }
+}
+
+fun DatabaseConnection.updateRecursiveTriggers(enabled: Boolean) {
+    withStatement("PRAGMA recursive_triggers=${enabled.toInt()}") { execute() }
+}
+
+private fun Boolean.toInt(): Int = if (this) 1 else 0


### PR DESCRIPTION
* Support the `recursive_triggers` and `synchronous` pragmas.
* Change the `foreign_keys` pramga to be always set on every connection regardless of the flag value, as per SQLite official recommendation.