### PR TITLE
Fix deploy based on: https://youtrack.jetbrains.com/issue/KT-30498

### DIFF
--- a/sqliter-driver/build.gradle.kts
+++ b/sqliter-driver/build.gradle.kts
@@ -1,5 +1,5 @@
-import org.jetbrains.kotlin.konan.target.HostManager
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.konan.target.HostManager
 
 plugins {
     kotlin("multiplatform")
@@ -48,7 +48,7 @@ fun disableCompilation(targets: List<KotlinNativeTarget>) {
 }
 
 kotlin {
-    val knTargets = mutableListOf(
+    val knTargets = listOf(
         linuxX64(),
         mingwX64("mingw"),
         macosX64(),


### PR DESCRIPTION
This tries to fix the deployment based on: https://youtrack.jetbrains.com/issue/KT-30498

To be clear: I have no idea if this actually works as expected or not.
But when publishing locally it seems to work as expected:
```
{
  "formatVersion": "1.1",
  "component": {
    "group": "co.touchlab",
    "module": "sqliter-driver",
    "version": "1.0.4",
    "attributes": {
      "org.gradle.status": "release"
    }
  },
  "createdBy": {
    "gradle": {
      "version": "6.8.2",
      "buildId": "kcahui3fmfailn2txperp7ylmq"
    }
  },
  "variants": [
    {
      "name": "metadataApiElements",
      "attributes": {
        "org.gradle.usage": "kotlin-api",
        "org.jetbrains.kotlin.platform.type": "common"
      },
      "files": [
        {
          "name": "sqliter-driver-metadata-1.0.4.jar",
          "url": "sqliter-driver-1.0.4.jar",
          "size": 261,
          "sha512": "22d3e3d2b2d11f25161c81bf95f269ceafad68a535534d584b744693ff223cb959badddecf6330fd97eb288ad29957b6ac11001d7f91723bab318c92f9700471",
          "sha256": "93904b2ccaa0bf01c25fc984fc686a88f4eaa5575955ab027fdc2e3458fc6c79",
          "sha1": "6c4add6a953271b75b23d23b0dac350df23250d1",
          "md5": "abb1e44108c2e9083717c77f90a5007c"
        }
      ]
    },
    {
      "name": "iosArm32ApiElements-published",
      "attributes": {
        "artifactType": "org.jetbrains.kotlin.klib",
        "org.gradle.usage": "kotlin-api",
        "org.jetbrains.kotlin.native.target": "ios_arm32",
        "org.jetbrains.kotlin.platform.type": "native"
      },
      "available-at": {
        "url": "../../sqliter-driver-iosarm32/1.0.4/sqliter-driver-iosarm32-1.0.4.module",
        "group": "co.touchlab",
        "module": "sqliter-driver-iosarm32",
        "version": "1.0.4"
      }
    },
    {
      "name": "iosArm64ApiElements-published",
      "attributes": {
        "artifactType": "org.jetbrains.kotlin.klib",
        "org.gradle.usage": "kotlin-api",
        "org.jetbrains.kotlin.native.target": "ios_arm64",
        "org.jetbrains.kotlin.platform.type": "native"
      },
      "available-at": {
        "url": "../../sqliter-driver-iosarm64/1.0.4/sqliter-driver-iosarm64-1.0.4.module",
        "group": "co.touchlab",
        "module": "sqliter-driver-iosarm64",
        "version": "1.0.4"
      }
    },
    {
      "name": "iosX64ApiElements-published",
      "attributes": {
        "artifactType": "org.jetbrains.kotlin.klib",
        "org.gradle.usage": "kotlin-api",
        "org.jetbrains.kotlin.native.target": "ios_x64",
        "org.jetbrains.kotlin.platform.type": "native"
      },
      "available-at": {
        "url": "../../sqliter-driver-iosx64/1.0.4/sqliter-driver-iosx64-1.0.4.module",
        "group": "co.touchlab",
        "module": "sqliter-driver-iosx64",
        "version": "1.0.4"
      }
    },
    {
      "name": "linuxX64ApiElements-published",
      "attributes": {
        "artifactType": "org.jetbrains.kotlin.klib",
        "org.gradle.usage": "kotlin-api",
        "org.jetbrains.kotlin.native.target": "linux_x64",
        "org.jetbrains.kotlin.platform.type": "native"
      },
      "available-at": {
        "url": "../../sqliter-driver-linuxx64/1.0.4/sqliter-driver-linuxx64-1.0.4.module",
        "group": "co.touchlab",
        "module": "sqliter-driver-linuxx64",
        "version": "1.0.4"
      }
    },
    {
      "name": "macosX64ApiElements-published",
      "attributes": {
        "artifactType": "org.jetbrains.kotlin.klib",
        "org.gradle.usage": "kotlin-api",
        "org.jetbrains.kotlin.native.target": "macos_x64",
        "org.jetbrains.kotlin.platform.type": "native"
      },
      "available-at": {
        "url": "../../sqliter-driver-macosx64/1.0.4/sqliter-driver-macosx64-1.0.4.module",
        "group": "co.touchlab",
        "module": "sqliter-driver-macosx64",
        "version": "1.0.4"
      }
    },
    {
      "name": "mingwApiElements-published",
      "attributes": {
        "org.gradle.usage": "kotlin-api",
        "org.jetbrains.kotlin.native.target": "mingw_x64",
        "org.jetbrains.kotlin.platform.type": "native"
      },
      "available-at": {
        "url": "../../sqliter-driver-mingw/1.0.4/sqliter-driver-mingw-1.0.4.module",
        "group": "co.touchlab",
        "module": "sqliter-driver-mingw",
        "version": "1.0.4"
      }
    },
    {
      "name": "tvosArm64ApiElements-published",
      "attributes": {
        "artifactType": "org.jetbrains.kotlin.klib",
        "org.gradle.usage": "kotlin-api",
        "org.jetbrains.kotlin.native.target": "tvos_arm64",
        "org.jetbrains.kotlin.platform.type": "native"
      },
      "available-at": {
        "url": "../../sqliter-driver-tvosarm64/1.0.4/sqliter-driver-tvosarm64-1.0.4.module",
        "group": "co.touchlab",
        "module": "sqliter-driver-tvosarm64",
        "version": "1.0.4"
      }
    },
    {
      "name": "tvosX64ApiElements-published",
      "attributes": {
        "artifactType": "org.jetbrains.kotlin.klib",
        "org.gradle.usage": "kotlin-api",
        "org.jetbrains.kotlin.native.target": "tvos_x64",
        "org.jetbrains.kotlin.platform.type": "native"
      },
      "available-at": {
        "url": "../../sqliter-driver-tvosx64/1.0.4/sqliter-driver-tvosx64-1.0.4.module",
        "group": "co.touchlab",
        "module": "sqliter-driver-tvosx64",
        "version": "1.0.4"
      }
    },
    {
      "name": "watchosArm32ApiElements-published",
      "attributes": {
        "artifactType": "org.jetbrains.kotlin.klib",
        "org.gradle.usage": "kotlin-api",
        "org.jetbrains.kotlin.native.target": "watchos_arm32",
        "org.jetbrains.kotlin.platform.type": "native"
      },
      "available-at": {
        "url": "../../sqliter-driver-watchosarm32/1.0.4/sqliter-driver-watchosarm32-1.0.4.module",
        "group": "co.touchlab",
        "module": "sqliter-driver-watchosarm32",
        "version": "1.0.4"
      }
    },
    {
      "name": "watchosArm64ApiElements-published",
      "attributes": {
        "artifactType": "org.jetbrains.kotlin.klib",
        "org.gradle.usage": "kotlin-api",
        "org.jetbrains.kotlin.native.target": "watchos_arm64",
        "org.jetbrains.kotlin.platform.type": "native"
      },
      "available-at": {
        "url": "../../sqliter-driver-watchosarm64/1.0.4/sqliter-driver-watchosarm64-1.0.4.module",
        "group": "co.touchlab",
        "module": "sqliter-driver-watchosarm64",
        "version": "1.0.4"
      }
    },
    {
      "name": "watchosX64ApiElements-published",
      "attributes": {
        "artifactType": "org.jetbrains.kotlin.klib",
        "org.gradle.usage": "kotlin-api",
        "org.jetbrains.kotlin.native.target": "watchos_x64",
        "org.jetbrains.kotlin.platform.type": "native"
      },
      "available-at": {
        "url": "../../sqliter-driver-watchosx64/1.0.4/sqliter-driver-watchosx64-1.0.4.module",
        "group": "co.touchlab",
        "module": "sqliter-driver-watchosx64",
        "version": "1.0.4"
      }
    },
    {
      "name": "watchosX86ApiElements-published",
      "attributes": {
        "artifactType": "org.jetbrains.kotlin.klib",
        "org.gradle.usage": "kotlin-api",
        "org.jetbrains.kotlin.native.target": "watchos_x86",
        "org.jetbrains.kotlin.platform.type": "native"
      },
      "available-at": {
        "url": "../../sqliter-driver-watchosx86/1.0.4/sqliter-driver-watchosx86-1.0.4.module",
        "group": "co.touchlab",
        "module": "sqliter-driver-watchosx86",
        "version": "1.0.4"
      }
    }
  ]
}
```