### PR TITLE
Expose database pointer

### DIFF
--- a/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/DatabaseConnection.kt
+++ b/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/DatabaseConnection.kt
@@ -16,6 +16,8 @@
 
 package co.touchlab.sqliter
 
+import co.touchlab.sqliter.interop.SqliteDatabasePointer
+
 interface DatabaseConnection {
     fun rawExecSql(sql: String)
     fun createStatement(sql: String): Statement
@@ -24,6 +26,7 @@ interface DatabaseConnection {
     fun endTransaction()
     fun close()
     val closed:Boolean
+    fun getDbPointer(): SqliteDatabasePointer
 }
 
 fun <R> DatabaseConnection.withStatement(sql: String, proc: Statement.() -> R): R {

--- a/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/concurrency/ConcurrentDatabaseConnection.kt
+++ b/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/concurrency/ConcurrentDatabaseConnection.kt
@@ -20,6 +20,7 @@ import co.touchlab.sqliter.Cursor
 import co.touchlab.sqliter.DatabaseConnection
 import co.touchlab.sqliter.FieldType
 import co.touchlab.sqliter.Statement
+import co.touchlab.sqliter.interop.SqliteDatabasePointer
 
 internal class ConcurrentDatabaseConnection(private val delegateConnection: DatabaseConnection) : DatabaseConnection {
     private val accessLock = Lock()
@@ -39,6 +40,8 @@ internal class ConcurrentDatabaseConnection(private val delegateConnection: Data
 
     override val closed: Boolean
         get() = delegateConnection.closed
+
+    override fun getDbPointer(): SqliteDatabasePointer = delegateConnection.getDbPointer()
 
     inner class ConcurrentCursor(private val delegateCursor: Cursor) : Cursor {
         override fun next(): Boolean = accessLock.withLock { delegateCursor.next() }

--- a/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/interop/SqliteDatabase.kt
+++ b/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/interop/SqliteDatabase.kt
@@ -5,7 +5,7 @@ import cnames.structs.sqlite3_stmt
 import kotlinx.cinterop.*
 import co.touchlab.sqliter.sqlite3.*
 
-internal class SqliteDatabase(path:String, label:String, val logger: Logger, private val verboseDataCalls: Boolean, val dbPointer:SqliteDatabasePointer) {
+internal class SqliteDatabase(path: String, label: String, val logger: Logger, private val verboseDataCalls: Boolean, val dbPointer: SqliteDatabasePointer) {
     val config = SqliteDatabaseConfig(path, label)
 
     fun prepareStatement(sqlString: String): SqliteStatement {

--- a/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/native/NativeDatabaseConnection.kt
+++ b/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/native/NativeDatabaseConnection.kt
@@ -20,6 +20,7 @@ import co.touchlab.sqliter.*
 import co.touchlab.sqliter.concurrency.Lock
 import co.touchlab.sqliter.concurrency.withLock
 import co.touchlab.sqliter.interop.SqliteDatabase
+import co.touchlab.sqliter.interop.SqliteDatabasePointer
 import co.touchlab.sqliter.util.maybeFreeze
 import kotlin.native.concurrent.AtomicInt
 import kotlin.native.concurrent.AtomicReference
@@ -85,6 +86,8 @@ class NativeDatabaseConnection internal constructor(
 
     override val closed: Boolean
         get() = closedFlag.value != 0
+
+    override fun getDbPointer(): SqliteDatabasePointer = sqliteDatabase.dbPointer
 
     fun migrateIfNeeded(
         create: (DatabaseConnection) -> Unit,


### PR DESCRIPTION
This would allow users to access the db pointer without having to expose the SqliteDatabase and without requiring casting to the NativeDatabaseConnection.

As discussed here: https://github.com/touchlab/SQLiter/pull/67, sometimes the db pointer is needed to perform specific tasks with the db. I think it would be better to expose this intentionally as part of the api rather than having to access this by casting to the native database connection.