### PR TITLE
Address the various build warnings across the app after updating to 1.7.20 beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 
 GROUP=co.touchlab
 VERSION_NAME=1.2.0
-KOTLIN_VERSION=1.6.20
+KOTLIN_VERSION=1.7.20-Beta
 
 kotlin.native.ignoreDisabledTargets=true
 
@@ -23,7 +23,5 @@ POM_DEVELOPER_NAME=Kevin Galligan
 POM_DEVELOPER_ORG=Kevin Galligan
 POM_DEVELOPER_URL=https://touchlab.co/
 
-kotlin.mpp.enableGranularSourceSetsMetadata=true
-kotlin.native.enableDependencyPropagation=false
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.commonizerLogLevel=info

--- a/sqliter-driver/src/appleMain/kotlin/co/touchlab/sqliter/DatabaseFileContext.kt
+++ b/sqliter-driver/src/appleMain/kotlin/co/touchlab/sqliter/DatabaseFileContext.kt
@@ -18,6 +18,7 @@ package co.touchlab.sqliter
 
 import co.touchlab.sqliter.internal.File
 import co.touchlab.sqliter.internal.FileFilter
+import kotlinx.cinterop.UnsafeNumber
 import platform.Foundation.NSApplicationSupportDirectory
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSSearchPathForDirectoriesInDomains
@@ -34,6 +35,7 @@ actual object DatabaseFileContext{
 
     internal fun databaseDirPath():String = iosDirPath("databases")
 
+    @OptIn(UnsafeNumber::class)
     internal fun iosDirPath(folder:String):String{
         val paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, true);
         val documentsDirectory = paths[0] as String;

--- a/sqliter-driver/src/linuxX64Main/kotlin/co/touchlab/sqliter/DatabaseFileContext.kt
+++ b/sqliter-driver/src/linuxX64Main/kotlin/co/touchlab/sqliter/DatabaseFileContext.kt
@@ -46,8 +46,8 @@ actual object DatabaseFileContext {
         if (dir != null) {
             val prefix = file.getName() + "-mj"
             val files = dir.listFiles(object : FileFilter {
-                override fun accept(candidate: File): Boolean {
-                    return candidate.getName().startsWith(prefix)
+                override fun accept(pathname: File): Boolean {
+                    return pathname.getName().startsWith(prefix)
                 }
             })
             if (files != null) {

--- a/sqliter-driver/src/linuxX64Main/kotlin/co/touchlab/sqliter/internal/File.kt
+++ b/sqliter-driver/src/linuxX64Main/kotlin/co/touchlab/sqliter/internal/File.kt
@@ -330,7 +330,7 @@ internal actual class File(dirPath: String? = null, name: String) {
         }
         val result = ArrayList<String>(filenames.size)
         for (filename in filenames) {
-            if (filter!!.accept(this, filename)) {
+            if (filter.accept(this, filename)) {
                 result.add(filename)
             }
         }
@@ -389,7 +389,7 @@ internal actual class File(dirPath: String? = null, name: String) {
         }
         val result = ArrayList<File>(files.size)
         for (file in files) {
-            if (filter!!.accept(file)) {
+            if (filter.accept(file)) {
                 result.add(file)
             }
         }
@@ -407,10 +407,8 @@ internal actual class File(dirPath: String? = null, name: String) {
             return null
         }
         val count = filenames.size
-        val result = arrayOfNulls<File>(count)
 
-        val files = Array<File>(count, { i -> File(this, filenames[i]) })
-        return files
+        return Array(count) { i -> File(this, filenames[i]) }
     }
 
     /**
@@ -454,6 +452,7 @@ internal actual class File(dirPath: String? = null, name: String) {
         return mkdirs(false)
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private fun mkdirs(resultIfExists: Boolean): Boolean {
         /* If the terminal directory already exists, answer false */
         if (exists()) {

--- a/sqliter-driver/src/mingwMain/kotlin/co/touchlab/sqliter/DatabaseFileContext.kt
+++ b/sqliter-driver/src/mingwMain/kotlin/co/touchlab/sqliter/DatabaseFileContext.kt
@@ -28,8 +28,8 @@ actual object DatabaseFileContext {
         if (dir != null) {
             val prefix = file.getName() + "-mj"
             val files = dir.listFiles(object: FileFilter {
-                override fun accept(candidate: File):Boolean {
-                    return candidate.getName().startsWith(prefix)
+                override fun accept(pathname: File):Boolean {
+                    return pathname.getName().startsWith(prefix)
                 }
             })
             if (files != null) {

--- a/sqliter-driver/src/mingwMain/kotlin/co/touchlab/sqliter/internal/Utils.kt
+++ b/sqliter-driver/src/mingwMain/kotlin/co/touchlab/sqliter/internal/Utils.kt
@@ -2,6 +2,7 @@ package co.touchlab.sqliter.internal
 
 import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.sizeOf
 import kotlinx.cinterop.toKString
 import platform.windows.GetEnvironmentVariableW
 import platform.windows.WCHARVar
@@ -14,9 +15,9 @@ internal class Utils {
             return getEnvironmentVariable("USERPROFILE")
         }
 
-        fun getEnvironmentVariable(variable: String): String {
+        private fun getEnvironmentVariable(variable: String): String {
             return memScoped {
-                val size = 1024 * WCHARVar.size
+                val size = 1024 * sizeOf<WCHARVar>()
                 val pointer = allocArray<WCHARVar>(size)
                 GetEnvironmentVariableW(variable, pointer, size.toUInt())
                 pointer.toKString()

--- a/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/concurrency/SingleThreadDatabaseConnection.kt
+++ b/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/concurrency/SingleThreadDatabaseConnection.kt
@@ -17,12 +17,11 @@
 package co.touchlab.sqliter.concurrency
 
 import co.touchlab.sqliter.DatabaseConnection
-import kotlin.native.concurrent.ensureNeverFrozen
+import co.touchlab.sqliter.util.ensureNeverFrozenIfStrictMM
 
 internal class SingleThreadDatabaseConnection(delegateConnection: DatabaseConnection):DatabaseConnection by delegateConnection
 {
     init {
-        if (Platform.memoryModel == MemoryModel.STRICT)
-            ensureNeverFrozen()
+        ensureNeverFrozenIfStrictMM()
     }
 }

--- a/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/util/Functions.kt
+++ b/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/util/Functions.kt
@@ -1,9 +1,17 @@
 package co.touchlab.sqliter.util
 
+import kotlin.native.concurrent.ensureNeverFrozen
 import kotlin.native.concurrent.freeze
 
+@OptIn(FreezingIsDeprecated::class)
 internal inline fun <T> T.maybeFreeze(): T = if (Platform.memoryModel == MemoryModel.STRICT) {
     this.freeze()
 } else {
     this
+}
+
+@OptIn(FreezingIsDeprecated::class)
+internal inline fun <T> T.ensureNeverFrozenIfStrictMM() {
+    if (Platform.memoryModel == MemoryModel.STRICT)
+        this?.ensureNeverFrozen()
 }

--- a/sqliter-driver/src/nativeCommonTest/kotlin/co/touchlab/sqliter/TestSupport.kt
+++ b/sqliter-driver/src/nativeCommonTest/kotlin/co/touchlab/sqliter/TestSupport.kt
@@ -16,16 +16,16 @@
 
 package co.touchlab.sqliter
 
+import co.touchlab.sqliter.util.maybeFreeze
 import kotlin.native.concurrent.Future
 import kotlin.native.concurrent.TransferMode
 import kotlin.native.concurrent.Worker
-import kotlin.native.concurrent.freeze
 import kotlin.system.getTimeMillis
 
 class MPWorker(){
     val worker = Worker.start()
     fun <T> runBackground(backJob: () -> T): MPFuture<T> {
-        return MPFuture(worker.execute(TransferMode.SAFE, {backJob.freeze()}){
+        return MPFuture(worker.execute(TransferMode.SAFE, {backJob.maybeFreeze()}){
             it()
         })
     }
@@ -61,7 +61,7 @@ class ThreadOps<C>(val producer:()->C){
             tests.shuffle()
         }
 
-        exes.freeze()
+        exes.maybeFreeze()
 
         val start = currentTimeMillis()
 

--- a/sqliter-driver/src/nativeCommonTest/kotlin/co/touchlab/sqliter/concurrency/ConcurrentDatabaseConnectionTest.kt
+++ b/sqliter-driver/src/nativeCommonTest/kotlin/co/touchlab/sqliter/concurrency/ConcurrentDatabaseConnectionTest.kt
@@ -17,7 +17,7 @@
 package co.touchlab.sqliter.concurrency
 
 import co.touchlab.sqliter.*
-import kotlin.native.concurrent.freeze
+import co.touchlab.sqliter.util.maybeFreeze
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -78,7 +78,7 @@ class ConcurrentDatabaseConnectionTest {
         basicTestDb(TWO_COL) {
             val conn = it.createSingleThreadedConnection()
             try {
-                assertFails { conn.freeze() }
+                assertFails { conn.maybeFreeze() }
             } catch (assertion: AssertionError) {
                 throw assertion
             } finally {


### PR DESCRIPTION
Explicit freezing in tests moved to calling the same "maybeFreeze" function to match production.  Similar method added to ensure never frozen, for strict memory model.

Other changes suggested by the IDE to address method argument names.

Opted in via an annotation for `UnsafeNumber` - although the constant can change between platforms, we are only building an iOS version of the code.

Tests and the build ran clean.