### PR TITLE
Handle file:// url prefix when fixing the databasePath

### DIFF
--- a/sqliter-driver/src/appleMain/kotlin/co/touchlab/sqliter/internal/File.kt
+++ b/sqliter-driver/src/appleMain/kotlin/co/touchlab/sqliter/internal/File.kt
@@ -77,7 +77,8 @@ internal actual class File(dirPath:String?=null, name:String){
         val newPath:CharArray = origPath.toCharArray()
         val length = newPath.size
         var newLength = 0
-        for (i in 0 until length) {
+        val initialIndex = if (origPath.startsWith("file://", true)) 7 else 0
+        for (i in initialIndex until length) {
             val ch = newPath[i]
             if (ch == '/') {
                 if (!lastWasSlash) {
@@ -93,15 +94,12 @@ internal actual class File(dirPath:String?=null, name:String){
         if (lastWasSlash && newLength > 1) {
             newLength--
         }
+
         // Reuse the original string if possible.
-        return if (newLength != length) {
-            val sb = StringBuilder(newLength)
-            sb.append(newPath)
-            sb.toString()
-        }
-        else {
-            origPath
-        }
+        return if (newLength != length) buildString(newLength) {
+            append(newPath)
+            setLength(newLength)
+        } else origPath
     }
 
     private fun join(prefix: String, suffix: String): String {

--- a/sqliter-driver/src/linuxX64Main/kotlin/co/touchlab/sqliter/internal/File.kt
+++ b/sqliter-driver/src/linuxX64Main/kotlin/co/touchlab/sqliter/internal/File.kt
@@ -94,7 +94,8 @@ internal actual class File(dirPath: String? = null, name: String) {
         val newPath: CharArray = origPath.toCharArray()
         val length = newPath.size
         var newLength = 0
-        for (i in 0 until length) {
+        val initialIndex = if (origPath.startsWith("file://", true)) 7 else 0
+        for (i in initialIndex until length) {
             val ch = newPath[i]
             if (ch == '/') {
                 if (!lastWasSlash) {
@@ -110,12 +111,12 @@ internal actual class File(dirPath: String? = null, name: String) {
         if (lastWasSlash && newLength > 1) {
             newLength--
         }
+
         // Reuse the original string if possible.
-        return if (newLength != length) {
-            newPath.concatToString()
-        } else {
-            origPath
-        }
+        return if (newLength != length) buildString(newLength) {
+            append(newPath)
+            setLength(newLength)
+        } else origPath
     }
 
     private fun join(prefix: String, suffix: String): String {

--- a/sqliter-driver/src/mingwMain/kotlin/co/touchlab/sqliter/internal/File.kt
+++ b/sqliter-driver/src/mingwMain/kotlin/co/touchlab/sqliter/internal/File.kt
@@ -78,7 +78,9 @@ internal actual class File(dirPath:String? = null, name:String) {
         val newPath:CharArray = origPath.toCharArray()
         val length = newPath.size
         var newLength = 0
-        for (ch in newPath) {
+        val initialIndex = if (origPath.startsWith("file://", true)) 7 else 0
+        for (i in initialIndex until length) {
+            val ch = newPath[i]
             if (ch == separatorChar) {
                 if (!lastWasSlash) {
                     newPath[newLength++] = separatorChar
@@ -94,12 +96,12 @@ internal actual class File(dirPath:String? = null, name:String) {
         if (lastWasSlash && newLength > 1) {
             newLength--
         }
+
         // Reuse the original string if possible.
-        return if (newLength != length) {
-            newPath.concatToString()
-        } else {
-            origPath
-        }
+        return if (newLength != length) buildString(newLength) {
+            append(newPath)
+            setLength(newLength)
+        } else origPath
     }
 
     /**

--- a/sqliter-driver/src/nativeCommonTest/kotlin/co/touchlab/sqliter/DatabaseConfigurationTest.kt
+++ b/sqliter-driver/src/nativeCommonTest/kotlin/co/touchlab/sqliter/DatabaseConfigurationTest.kt
@@ -27,6 +27,24 @@ class DatabaseConfigurationTest : BaseDatabaseTest(){
     }
 
     @Test
+    fun databasePathRemovesExtraSlashes() {
+        val dbPathString = DatabaseFileContext.databasePath(TEST_DB_NAME, "//tmp//")
+        assertEquals("/tmp/$TEST_DB_NAME", dbPathString)
+    }
+
+    @Test
+    fun databasePathRemovesFileUrlPrefix() {
+        val dbPathString = DatabaseFileContext.databasePath(TEST_DB_NAME, "file:///tmp/")
+        assertEquals("/tmp/$TEST_DB_NAME", dbPathString)
+    }
+
+    @Test
+    fun databasePathRemovesFileUrlPrefixInCaps() {
+        val dbPathString = DatabaseFileContext.databasePath(TEST_DB_NAME, "FILE:///tmp/")
+        assertEquals("/tmp/$TEST_DB_NAME", dbPathString)
+    }
+
+    @Test
     fun memoryOnlyTest(){
         val conf = DatabaseConfiguration(
             name = null,


### PR DESCRIPTION
Fixed a bug where the database path gained extraneous characters on the end if slashes got stripped from earlier in the string, and added handling for `file://` url prefixes in the string, stripping them off as required.

Fixes #57 