### PR TITLE
Fix when SELECT columns those have same name in JOIN statement

### DIFF
--- a/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/native/NativeCursor.kt
+++ b/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/native/NativeCursor.kt
@@ -37,7 +37,18 @@ class NativeCursor(override val statement: NativeStatement) : Cursor {
     override val columnNames: Map<String, Int> by lazy {
         val map = HashMap<String, Int>(this.columnCount)
         for (i in 0 until columnCount) {
-            map.put(columnName(i), i)
+            val key = columnName(i)
+            if (map.containsKey(key)) {
+                var index = 1
+                val basicKey = "$key&JOIN"
+                var finalKey = basicKey + index
+                while (map.containsKey(finalKey)) {
+                    finalKey = basicKey + ++index
+                }
+                map[finalKey] = i
+            } else {
+                map[key] = i
+            }
         }
         map
     }


### PR DESCRIPTION
If we execute a JOIN (cross join or join with a `ON` clause) SQL statement:

```sql
SELECT person.name, student.name, age, specialized FROM person CROSS JOIN student;
```
We will get two columns those named "name". Now in NativeCursor, the index of second "name" will replace index of first "name" in `columnNames`, and users can never get the index of first "name" in `columnNames`. So, I provide a solution that if `columnNames` contains the "name", the second "name" will be rename to "name&JOIN1", and If we have three "name", the third will be named to "name&JOIN2", etc..