### PR TITLE
Small changes to support Kotlin 1.8.0-RC

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ kotlin.code.style=official
 GROUP=co.touchlab
 
 VERSION_NAME=1.2.2
-KOTLIN_VERSION=1.8.0-RC
+KOTLIN_VERSION=1.8.0
 
 kotlin.native.ignoreDisabledTargets=true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ kotlin.code.style=official
 GROUP=co.touchlab
 
 VERSION_NAME=1.2.2
-KOTLIN_VERSION=1.7.20
+KOTLIN_VERSION=1.8.0-RC
 
 kotlin.native.ignoreDisabledTargets=true
 
@@ -26,3 +26,4 @@ POM_DEVELOPER_URL=https://touchlab.co/
 
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.commonizerLogLevel=info
+kotlin.daemon.jvmargs=-Xmx3g

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,5 +8,3 @@ pluginManagement {
     kotlin("multiplatform") version KOTLIN_VERSION
   }
 }
-
-enableFeaturePreview("GRADLE_METADATA")

--- a/sqliter-driver/build.gradle.kts
+++ b/sqliter-driver/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.konan.target.HostManager
 
 plugins {
@@ -10,50 +11,28 @@ val VERSION_NAME: String by project
 group = GROUP
 version = VERSION_NAME
 
-fun configInterop(target: org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget) {
-    val main by target.compilations.getting
-    val sqlite3 by main.cinterops.creating {
-        includeDirs("$projectDir/src/include")
-//      extraOpts = listOf("-mode", "sourcecode")
-    }
-
-    target.compilations.forEach { kotlinNativeCompilation ->
-        kotlinNativeCompilation.kotlinOptions.freeCompilerArgs += when {
-            HostManager.hostIsLinux -> listOf(
-                "-linker-options",
-                "-lsqlite3 -L/usr/lib/x86_64-linux-gnu -L/usr/lib"
-            )
-            HostManager.hostIsMingw -> listOf("-linker-options", "-lsqlite3 -Lc:\\msys64\\mingw64\\lib")
-            else -> listOf("-linker-options", "-lsqlite3")
-        }
-    }
-}
-
 kotlin {
     val knTargets = listOf(
-            macosX64(),
-            iosX64(),
-            iosArm64(),
-            iosArm32(),
-            watchosArm32(),
-            watchosArm64(),
-            watchosX86(),
-            watchosX64(),
-            tvosArm64(),
-            tvosX64(),
-            macosArm64(),
-            iosSimulatorArm64(),
-            watchosSimulatorArm64(),
-            tvosSimulatorArm64(),
-            mingwX64(),
-            mingwX86(),
-            linuxX64()
-        )
+        macosX64(),
+        iosX64(),
+        iosArm64(),
+        iosArm32(),
+        watchosArm32(),
+        watchosArm64(),
+        watchosX86(),
+        watchosX64(),
+        tvosArm64(),
+        tvosX64(),
+        macosArm64(),
+        iosSimulatorArm64(),
+        watchosSimulatorArm64(),
+        tvosSimulatorArm64(),
+        mingwX64(),
+        mingwX86(),
+        linuxX64()
+    )
 
-    knTargets
-        .forEach { target ->
-            configInterop(target)
-        }
+    knTargets.forEach(::configInterop)
 
     sourceSets {
         commonMain {
@@ -77,7 +56,7 @@ kotlin {
         val linuxMain = sourceSets.maybeCreate("linuxX64Main").apply {
             dependsOn(nativeCommonMain)
         }
-        
+
         val mingwMain = sourceSets.maybeCreate("mingwMain").apply {
             dependsOn(nativeCommonMain)
         }
@@ -91,31 +70,36 @@ kotlin {
         }
 
         knTargets.forEach { target ->
+            target.binaries.all {
+                freeCompilerArgs = freeCompilerArgs.plus(linkerArgs())
+            }
+
             when {
                 target.name.startsWith("mingw") -> {
                     target.compilations.getByName("main").defaultSourceSet.dependsOn(mingwMain)
                     target.compilations.getByName("test").defaultSourceSet.dependsOn(nativeCommonTest)
                 }
+
                 target.name.startsWith("linux") -> {
                     target.compilations.getByName("test").defaultSourceSet.dependsOn(nativeCommonTest)
                 }
+
                 else -> {
                     target.compilations.getByName("main").defaultSourceSet.dependsOn(appleMain)
                     target.compilations.getByName("test").defaultSourceSet.dependsOn(nativeCommonTest)
                 }
             }
-
         }
     }
 }
 
-if(!HostManager.hostIsLinux) {
+if (!HostManager.hostIsLinux) {
     tasks.findByName("linuxX64Test")?.enabled = false
     tasks.findByName("linkDebugTestLinuxX64")?.enabled = false
     tasks.findByName("publishLinuxX64PublicationToMavenRepository")?.enabled = false
 }
 
-if(!HostManager.hostIsMingw) {
+if (!HostManager.hostIsMingw) {
     tasks.findByName("mingwX64Test")?.enabled = false
     tasks.findByName("linkDebugTestMingwX64")?.enabled = false
     tasks.findByName("publishMingwX64PublicationToMavenRepository")?.enabled = false
@@ -123,6 +107,36 @@ if(!HostManager.hostIsMingw) {
 
 apply(from = "../gradle/gradle-mvn-mpp-push.gradle")
 
-tasks.register("publishMac"){
-    setDependsOn(tasks.filter { t -> t.name.startsWith("publish") && t.name.endsWith("ToMavenRepository") && !t.name.contains("Linux") }.map { it.name })
+tasks.register("publishMac") {
+    setDependsOn(tasks.filter { t ->
+        t.name.startsWith("publish") &&
+        t.name.endsWith("ToMavenRepository") &&
+        !t.name.contains("Linux")
+    }.map {
+        it.name
+    })
+}
+
+fun configInterop(target: KotlinNativeTarget) {
+    val main by target.compilations.getting
+    val sqlite3 by main.cinterops.creating {
+        includeDirs("$projectDir/src/include")
+    }
+}
+
+fun linkerArgs() = when {
+    HostManager.hostIsLinux -> listOf(
+        "-linker-options",
+        "-lsqlite3 -L/usr/lib/x86_64-linux-gnu -L/usr/lib"
+    )
+
+    HostManager.hostIsMingw -> listOf(
+        "-linker-options",
+        "-lsqlite3 -Lc:\\msys64\\mingw64\\lib"
+    )
+
+    else -> listOf(
+        "-linker-options",
+        "-lsqlite3"
+    )
 }

--- a/sqliter-driver/build.gradle.kts
+++ b/sqliter-driver/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
         watchosArm64(),
         watchosX86(),
         watchosX64(),
+        watchosDeviceArm64(),
         tvosArm64(),
         tvosX64(),
         macosArm64(),


### PR DESCRIPTION
Notable change - version `1.7.20` was passing linker options through to the final (test) executable, and the `1.8.0-RC` is not.  Moving the linker flag application slightly makes the tests run correctly on both `1.7.20` and on `1.8.0-RC`.