### PR TITLE
Support binding an empty ByteArray to a BLOB

### DIFF
--- a/sqliter-driver/src/nativeCommonTest/kotlin/co/touchlab/sqliter/NativeStatementTest.kt
+++ b/sqliter-driver/src/nativeCommonTest/kotlin/co/touchlab/sqliter/NativeStatementTest.kt
@@ -218,25 +218,25 @@ class NativeStatementTest : BaseDatabaseTest(){
         }
     }
 
-    val TWO_COL_WITH_BLOB = "CREATE TABLE test (num INTEGER NOT NULL, " +
-            "blb BLOB NOT NULL)"
+    val THREE_COL_WITH_BLOB = "CREATE TABLE test (num INTEGER NOT NULL, " +
+            "blb BLOB NOT NULL, null_blb BLOB)"
 
-//    @Test
-    // Need to review what other drivers do here. It's not acting as expected
-    // https://github.com/touchlab/SQLiter/issues/62
+    @Test
     fun bindEmptyBlob() {
-        basicTestDb(TWO_COL_WITH_BLOB) {
+        basicTestDb(THREE_COL_WITH_BLOB) {
             it.withConnection {
-                it.withStatement("insert into test(num, blb)values(?,?)") {
+                it.withStatement("insert into test(num, blb, null_blb)values(?,?,?)") {
                     bindLong(1, 22)
-                    bindBlob(2, ByteArray(0){it.toByte()})
+                    bindBlob(2, byteArrayOf())
+                    bindBlob(3, null)
                     executeInsert()
                 }
 
-                it.withStatement("select blb from test") {
+                it.withStatement("select blb, null_blb from test") {
                     val query = query()
                     query.next()
                     assertEquals(query.getBytes(query.columnNames["blb"]!!).size, 0)
+                    assertEquals(query.getBytesOrNull(query.columnNames["null_blb"]!!), null)
                 }
             }
         }
@@ -244,7 +244,7 @@ class NativeStatementTest : BaseDatabaseTest(){
 
     @Test
     fun bindBlob() {
-        basicTestDb(TWO_COL_WITH_BLOB) {
+        basicTestDb(THREE_COL_WITH_BLOB) {
             it.withConnection {
                 it.withTransaction {
                     it.withStatement("insert into test(num, blb)values(?,?)") {


### PR DESCRIPTION
If you try to bind an empty `ByteArray` it will crash because `ByteArray.refTo(0)` cannot find an element at index 0. The solution is to explicitly handle when the `ByteArray` is empty and to make an empty `BLOB`.

I looked around to see how other bindings handle it and [rusqlite](https://github.com/rusqlite/rusqlite/blob/bff475061a10d1fc9e33b223a49635c41d1b1b2a/src/statement.rs#L762-L776) uses `sqlite3_bind_zeroblob()`.

If any changes are needed to get this merged, I am happy to make them, but also feel free to make any changes yourselves!