### PR TITLE
Add support for binding empty bytes.

### DIFF
--- a/sqliter-driver/src/nativeCommonTest/kotlin/co/touchlab/sqliter/NativeStatementTest.kt
+++ b/sqliter-driver/src/nativeCommonTest/kotlin/co/touchlab/sqliter/NativeStatementTest.kt
@@ -221,9 +221,7 @@ class NativeStatementTest : BaseDatabaseTest(){
     val TWO_COL_WITH_BLOB = "CREATE TABLE test (num INTEGER NOT NULL, " +
             "blb BLOB NOT NULL)"
 
-//    @Test
-    // Need to review what other drivers do here. It's not acting as expected
-    // https://github.com/touchlab/SQLiter/issues/62
+    @Test
     fun bindEmptyBlob() {
         basicTestDb(TWO_COL_WITH_BLOB) {
             it.withConnection {


### PR DESCRIPTION
Fix #42, refer: [The return value from sqlite3_column_blob() for a zero-length BLOB is a NULL pointer.](https://www.sqlite.org/c3ref/column_blob.html)