### PR TITLE
Add check for purely in-memory or temporary database when incrementing `newConnection`

### DIFF
--- a/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/native/NativeDatabaseManager.kt
+++ b/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/native/NativeDatabaseManager.kt
@@ -98,7 +98,7 @@ class NativeDatabaseManager(private val path:String,
                     throw e
                 }
 
-                // Temporary, or purely in-memory databases live only as long
+                // "Temporary" and "purely in-memory" databases live only as long
                 // as the connection. Subsequent connections (even if open at
                 // the same time) are completely separate databases.
                 //

--- a/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/native/NativeDatabaseManager.kt
+++ b/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/native/NativeDatabaseManager.kt
@@ -103,7 +103,7 @@ class NativeDatabaseManager(private val path:String,
                 // the same time) are completely separate databases.
                 //
                 // If this is the case, do not increment newConnection so that
-                // this if block executes on every new connection (i.e. ever new
+                // this if block executes on every new connection (i.e. every new
                 // ephemeral database).
                 when (path) {
                     "", ":memory:" -> {}

--- a/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/native/NativeDatabaseManager.kt
+++ b/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/native/NativeDatabaseManager.kt
@@ -97,7 +97,18 @@ class NativeDatabaseManager(private val path:String,
                     conn.close()
                     throw e
                 }
-                newConnection.increment()
+
+                // Temporary, or purely in-memory databases live only as long
+                // as the connection. Subsequent connections (even if open at
+                // the same time) are completely separate databases.
+                //
+                // If this is the case, do not increment newConnection so that
+                // this if block executes on every new connection (i.e. ever new
+                // ephemeral database).
+                when (path) {
+                    "", ":memory:" -> {}
+                    else -> newConnection.increment()
+                }
             }
 
             conn

--- a/sqliter-driver/src/nativeCommonTest/kotlin/co/touchlab/sqliter/DatabaseConfigurationTest.kt
+++ b/sqliter-driver/src/nativeCommonTest/kotlin/co/touchlab/sqliter/DatabaseConfigurationTest.kt
@@ -59,6 +59,19 @@ class DatabaseConfigurationTest : BaseDatabaseTest(){
     }
 
     @Test
+    fun temporaryOnlyTest(){
+        val conf = DatabaseConfiguration(
+            name = "",
+            inMemory = false,
+            version = 1,
+            create = {},
+            extendedConfig = DatabaseConfiguration.Extended(basePath = ""),
+        )
+        val dbPathString = diskOrMemoryPath(conf)
+        assertEquals("", dbPathString)
+    }
+
+    @Test
     fun memoryPathTest(){
         val conf = DatabaseConfiguration(
             name = TEST_DB_NAME,

--- a/sqliter-driver/src/nativeCommonTest/kotlin/co/touchlab/sqliter/DatabaseConnectionTest.kt
+++ b/sqliter-driver/src/nativeCommonTest/kotlin/co/touchlab/sqliter/DatabaseConnectionTest.kt
@@ -255,17 +255,6 @@ class DatabaseConnectionTest {
 
         assertEquals(1, conn1.longForQuery("select count(*) from test"))
 
-        assertFails {
-            val connFail = man.surpriseMeConnection()
-            connFail.withTransaction {
-                it.withStatement("insert into test(num, str)values(?,?)") {
-                    bindLong(1, 232)
-                    bindString(2, "asdf")
-                    executeInsert()
-                }
-            }
-        }
-
         val man2 = createDatabaseManager(
             conf
         )
@@ -276,20 +265,23 @@ class DatabaseConnectionTest {
                 bindString(2, "asdf")
                 executeInsert()
             }
+            it.withStatement("insert into test(num, str)values(?,?)") {
+                bindLong(1, 233)
+                bindString(2, "asdfg")
+                executeInsert()
+            }
         }
 
-        assertEquals(1, conn2.longForQuery("select count(*) from test"))
+        assertEquals(1, conn1.longForQuery("select count(*) from test"))
 
         conn1.close()
 
-        assertEquals(1, conn2.longForQuery("select count(*) from test"))
+        assertEquals(2, conn2.longForQuery("select count(*) from test"))
 
         conn2.close()
 
-        assertFails {
-            man.withConnection {
-                assertEquals(0, it.longForQuery("select count(*) from test"))
-            }
+        man.withConnection {
+            assertEquals(0, it.longForQuery("select count(*) from test"))
         }
     }
 

--- a/sqliter-driver/src/nativeCommonTest/kotlin/co/touchlab/sqliter/DatabaseManagerTest.kt
+++ b/sqliter-driver/src/nativeCommonTest/kotlin/co/touchlab/sqliter/DatabaseManagerTest.kt
@@ -120,7 +120,7 @@ class DatabaseManagerTest : BaseDatabaseTest(){
 
         val conf = DatabaseConfiguration(
             name = "",
-            inMemory = true,
+            inMemory = false,
             version = 1,
             create = { db ->
                 creationCount++

--- a/sqliter-driver/src/nativeCommonTest/kotlin/co/touchlab/sqliter/DatabaseManagerTest.kt
+++ b/sqliter-driver/src/nativeCommonTest/kotlin/co/touchlab/sqliter/DatabaseManagerTest.kt
@@ -87,6 +87,66 @@ class DatabaseManagerTest : BaseDatabaseTest(){
     }
 
     @Test
+    fun createCalledEachNewConnectionWhenInMemory() {
+        var creationCount = 0
+
+        val conf = DatabaseConfiguration(
+            name = null,
+            inMemory = true,
+            version = 1, create = { db ->
+                creationCount++
+                db.withStatement(TWO_COL) {
+                    execute()
+                }
+            },
+        )
+
+        val mgr = createDatabaseManager(conf)
+        mgr.withConnection {
+            it.rawExecSql("INSERT INTO test(num, str)values(3,'abc')")
+            assertEquals(1, it.longForQuery("select count(*) from test"))
+
+            mgr.withConnection {
+                assertEquals(0, it.longForQuery("select count(*) from test"))
+            }
+        }
+
+        assertEquals(2, creationCount)
+    }
+
+    @Test
+    fun createCalledEachNewConnectionWhenTemporary() {
+        var creationCount = 0
+
+        val conf = DatabaseConfiguration(
+            name = "",
+            inMemory = true,
+            version = 1,
+            create = { db ->
+                creationCount++
+                db.withStatement(TWO_COL) {
+                    execute()
+                }
+            },
+            extendedConfig = DatabaseConfiguration.Extended(
+                basePath = ""
+            ),
+        )
+
+        val mgr = createDatabaseManager(conf)
+        mgr.withConnection { conn1 ->
+            conn1.rawExecSql("INSERT INTO test(num, str)values(3,'abc')")
+            assertEquals(1, conn1.longForQuery("select count(*) from test"))
+
+            mgr.withConnection { conn2 ->
+                assertEquals(0, conn2.longForQuery("select count(*) from test"))
+            }
+        }
+
+        assertEquals(2, creationCount)
+    }
+
+    @Test
     fun downgradeNotAllowed(){
         val upgradeCalled = AtomicInt(0)
         val config1 = DatabaseConfiguration(


### PR DESCRIPTION
Fixes #104 