### PR TITLE
Use autolinking on Apple platforms to prevent the need to link with sqlite3 explicitly

### DIFF
--- a/sqliter-driver/externalLinkageSources/lib.m
+++ b/sqliter-driver/externalLinkageSources/lib.m
@@ -1,0 +1,10 @@
+@import sqliteDriver;
+
+void forceSqliteSymbolsLoading(NSString * path, SqliteDriverDatabaseConfiguration * configuration) {
+  SqliteDriverNativeDatabaseManager * foo = [
+    [SqliteDriverNativeDatabaseManager alloc]
+    initWithPath: path
+    configuration: configuration
+  ];
+  [foo createSingleThreadedConnection];
+}

--- a/sqliter-driver/src/nativeInterop/cinterop/sqlite3.def
+++ b/sqliter-driver/src/nativeInterop/cinterop/sqlite3.def
@@ -5,4 +5,18 @@ headerFilter = sqlite3*.h
 linkerOpts.linux_x64 = -lpthread -ldl
 linkerOpts.macos_x64 = -lpthread -ldl
 
+compilerOpts.ios_arm64 = -Xclang --linker-option=-lsqlite3
+compilerOpts.ios_x64 = -Xclang --linker-option=-lsqlite3
+compilerOpts.ios_simulator_arm64 = -Xclang --linker-option=-lsqlite3
+compilerOpts.watchos_arm32 = -Xclang --linker-option=-lsqlite3
+compilerOpts.watchos_arm64 = -Xclang --linker-option=-lsqlite3
+compilerOpts.watchos_x64 = -Xclang --linker-option=-lsqlite3
+compilerOpts.watchos_simulator_arm64 = -Xclang --linker-option=-lsqlite3
+compilerOpts.watchos_device_arm64 = -Xclang --linker-option=-lsqlite3
+compilerOpts.tvos_arm64 = -Xclang --linker-option=-lsqlite3
+compilerOpts.tvos_x64 = -Xclang --linker-option=-lsqlite3
+compilerOpts.tvos_simulator_arm64 = -Xclang --linker-option=-lsqlite3
+compilerOpts.macos_x64 = -Xclang --linker-option=-lsqlite3
+compilerOpts.macos_arm64 = -Xclang --linker-option=-lsqlite3
+
 noStringConversion = sqlite3_prepare_v2 sqlite3_prepare_v3


### PR DESCRIPTION
On Apple platforms an explicit linking configuration is usually not required, because `clang` and `swiftc` compilers embed linker commands into `.o` files they produce. These linker commands can be printed out via `otool -l /path/to/object | grep -A 4 LC_LINKER_OPTION`.

This MR uses this technique to remove the requirement to explicitly link with `-lsqlite3` on Apple platforms by embedding `LC_LINKER_OPTION` command into object files produced by K/N. This may be most useful for projects that link against K/N static libraries in Xcode, but should also remove the need for [consumer side](https://github.com/cashapp/sqldelight/blob/24a14b889f8372337b47e836b4e8818bc761d391/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/kotlin/LinkSqlite.kt#L7-L15) linker configuration.

As an integration test, I [disabled](https://github.com/abdulowork/sqldelight/commit/205506f3bdce1c24e22ec57e7ee705a8de422e5f) explicit linking in sqldelight and ran the tests I could find against this MR: [1](https://github.com/abdulowork/sqldelight/actions/runs/8349261668), [2](https://github.com/abdulowork/sqldelight/actions/runs/8349840353)