### PR TITLE
Exclude SQLite symbols that aren't universally available

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 
 GROUP=co.touchlab
 
-VERSION_NAME=1.3.1
+VERSION_NAME=1.3.2
 KOTLIN_VERSION=1.9.20
 
 kotlin.native.ignoreDisabledTargets=true

--- a/sqliter-driver/src/nativeInterop/cinterop/sqlite3.def
+++ b/sqliter-driver/src/nativeInterop/cinterop/sqlite3.def
@@ -6,3 +6,14 @@ linkerOpts.linux_x64 = -lpthread -ldl
 linkerOpts.macos_x64 = -lpthread -ldl
 
 noStringConversion = sqlite3_prepare_v2 sqlite3_prepare_v3
+
+# These functions aren't guaranteed to be callable and we don't use them. The functions listed here
+# come from:
+#  - mutex_held / mutex_notheld: Debug only, https://sqlite.org/c3ref/mutex_held.html
+#  - column database / table / origin name: Opt-in, https://sqlite.org/c3ref/column_database_name.html
+#  - sqlite3_normalized_sql: Opt-in, https://sqlite.org/c3ref/expanded_sql.html
+#  - Snapshots: Opt-in, https://sqlite.org/compile.html#enable_snapshot
+#  - Scanstatus: Opt-in, https://sqlite.org/c3ref/stmt_scanstatus.html
+#  - sqlite3_unlock_notify: Opt-in, https://sqlite.org/unlock_notify.html
+#  - win32: Platform-specific, not used here, https://sqlite.org/c3ref/win32_set_directory.html
+excludedFunctions = sqlite3_mutex_held sqlite3_mutex_notheld sqlite3_column_database_name sqlite3_column_database_name16 sqlite3_column_table_name sqlite3_column_table_name16 sqlite3_column_origin_name sqlite3_column_origin_name16 sqlite3_normalized_sql sqlite3_snapshot_get sqlite3_snapshot_free sqlite3_snapshot_open sqlite3_snapshot_cmp sqlite3_snapshot_recover sqlite3_stmt_scanstatus sqlite3_stmt_scanstatus_reset sqlite3_unlock_notify sqlite3_win32_set_directory sqlite3_win32_set_directory8 sqlite3_win32_set_directory16


### PR DESCRIPTION
This excludes `sqlite3` symbols that are platform-specific or depend on optional SQLite features to ensure they're not linked by SQLiter.

Because cinterop otherwise just looks at `sqlite3.h` to determine symbols, it's possible that references to these symbols end up in compiled apps or frameworks when building Kotlin projects as libraries. Depending on how SQLite gets linked in the end, some of these symbols might not be available, causing linker errors.

Given that these functions are not used by SQLiter, we can simply exclude them from compilation.