### PR TITLE
Add DatabaseConfiguration.downgrade

### DIFF
--- a/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/DatabaseConfiguration.kt
+++ b/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/DatabaseConfiguration.kt
@@ -35,6 +35,9 @@ data class DatabaseConfiguration(
     val version: Int,
     val create: (DatabaseConnection) -> Unit,
     val upgrade: (DatabaseConnection, Int, Int) -> Unit = { _, _, _ -> },
+    val downgrade: (DatabaseConnection, Int, Int) -> Unit = { _, initialVersion, version ->
+        error("Database version $initialVersion newer than config version $version")
+    },
     val inMemory: Boolean = false,
     val journalMode: JournalMode = JournalMode.WAL,
     val extendedConfig:Extended = Extended(),

--- a/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/native/NativeDatabaseConnection.kt
+++ b/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/native/NativeDatabaseConnection.kt
@@ -92,6 +92,7 @@ class NativeDatabaseConnection internal constructor(
     fun migrateIfNeeded(
         create: (DatabaseConnection) -> Unit,
         upgrade: (DatabaseConnection, Int, Int) -> Unit,
+        downgrade: (DatabaseConnection, Int, Int) -> Unit,
         version: Int
     ) {
         this.withTransaction {
@@ -100,10 +101,11 @@ class NativeDatabaseConnection internal constructor(
                 create(this)
                 setVersion(version)
             } else if (initialVersion != version) {
-                if (initialVersion > version)
-                    throw IllegalStateException("Database version $initialVersion newer than config version $version")
-
-                upgrade(this, initialVersion, version)
+                if (initialVersion > version) {
+                    downgrade(this, initialVersion, version)
+                } else {
+                    upgrade(this, initialVersion, version)
+                }
                 setVersion(version)
             }
         }

--- a/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/native/NativeDatabaseManager.kt
+++ b/sqliter-driver/src/nativeCommonMain/kotlin/co/touchlab/sqliter/native/NativeDatabaseManager.kt
@@ -89,7 +89,7 @@ class NativeDatabaseManager(private val path:String,
                 try {
                     val version = configuration.version
                     if(version != NO_VERSION_CHECK)
-                        conn.migrateIfNeeded(configuration.create, configuration.upgrade, version)
+                        conn.migrateIfNeeded(configuration.create, configuration.upgrade, configuration.downgrade, version)
                 } catch (e: Exception) {
 
                     // If this failed, we have to close the connection or we will end up leaking it.


### PR DESCRIPTION
This allows clients to implement custom downgrade behavior (such as destructive migrations, etc).